### PR TITLE
Setup devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora:rawhide
+
+# Install rustup and Souk dependencies
+RUN dnf -y install \
+  rustup \
+  git \
+  meson \
+  cmake \
+  gcc \
+  openssl-devel \
+  flatpak-devel \
+  sqlite-devel \
+  dbus-devel \
+  gtk4-devel \
+  libadwaita-devel \
+  update-desktop-database \
+  libxmlb-devel
+
+# Install Rust
+RUN rustup-init -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Souk",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}


### PR DESCRIPTION
You can build the project within the devcontainer with the following:

```
$ meson setup build
$ meson compile -C build
```

Build artifacts will be in `./build/target/release/`.

If you aren't using vscode or devcontainer CLI, you can setup the devcontainer with docker (or podman):

```
$ docker build -t souk_devel .devcontainer/
$ docker run -it -v ./:/souk:Z souk_devel
# cd souk
```